### PR TITLE
chore: ignore jira-assistant-skills-lib directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ local/
 
 # Pre-commit
 .pre-commit-config.yaml.bak
+
+# Separate git repo (PyPI package)
+jira-assistant-skills-lib/


### PR DESCRIPTION
## Summary
- Add `jira-assistant-skills-lib/` to `.gitignore`

The library is a separate git repository published as a PyPI package (`grandcamel/jira-assistant-skills-lib`). Adding to `.gitignore` prevents it from showing as untracked in the parent repo.

## Test plan
- [x] Verify `git status` no longer shows lib as untracked

🤖 Generated with [Claude Code](https://claude.ai/claude-code)