### PR TITLE
fix: restore green ruff format gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ packages = []
 [tool.ruff]
 target-version = "py310"
 line-length = 88
+# Newer ruff releases format Python code blocks inside Markdown; this repo's
+# docs are prose-first, so keep ruff scoped to real Python files.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = [

--- a/skills/jira-assistant/tests/test_routing.py
+++ b/skills/jira-assistant/tests/test_routing.py
@@ -326,7 +326,7 @@ def run_claude_routing(
 
     # Verbose output for debugging (disable with ROUTING_TEST_QUIET=1)
     if not os.environ.get("ROUTING_TEST_QUIET"):
-        print(f"\n{'='*70}")
+        print(f"\n{'=' * 70}")
         print(f"INPUT: {input_text}")
         print(f"SESSION: {session_id}")
         print(f"SKILL DETECTED: {skill_loaded}")
@@ -334,7 +334,7 @@ def run_claude_routing(
         print(f"RESPONSE:\n{response_text}")
         if permission_denials:
             print(f"PERMISSION DENIALS: {json.dumps(permission_denials, indent=2)}")
-        print(f"{'='*70}\n")
+        print(f"{'=' * 70}\n")
 
     return RoutingResult(
         skill_loaded=skill_loaded,
@@ -789,7 +789,9 @@ def test_edge_cases(test_case, record_otel):
             )
         elif expected_action == "show_quick_reference":
             # Capability queries are flexible - asking clarification is acceptable
-            assert result.skill_loaded == expected_skill or result.asked_clarification, (
+            assert (
+                result.skill_loaded == expected_skill or result.asked_clarification
+            ), (
                 f"Expected {expected_skill} or clarification, got {result.skill_loaded}\n"
                 f"Input: '{input_text}'"
             )


### PR DESCRIPTION
## Summary

The **Lint & Format** job has been red on `main` since the tip commit (and PR #44 inherits it): CI installs unpinned latest ruff, and ruff ≥0.16 now format-checks Python code blocks embedded in Markdown, flagging 13 prose docs that no commit touched. This PR restores the gate to its original scope:

- `pyproject.toml`: `extend-exclude = ["*.md"]` under `[tool.ruff]` so ruff stays on real Python files.
- `skills/jira-assistant/tests/test_routing.py`: the one genuine finding, whitespace-only reformat.

Unblocks merging #44 (version sync) and the upcoming 4.3.0 parity PR with green checks.

## Test plan

- [x] `ruff format --check .` passes locally with ruff 0.16.3 (same unpinned-latest CI uses)
- [x] `ruff check .` passes
- [x] test_routing.py diff is formatting-only (f-string spacing, paren wrapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxXnxfFLGUyNbQT6TaTZWA